### PR TITLE
feat: add configurable runs-on input to build-and-publish-image-to-acr workflow

### DIFF
--- a/.github/workflows/build-and-publish-image-to-acr.yaml
+++ b/.github/workflows/build-and-publish-image-to-acr.yaml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: 'latest'
+      RUNS_ON:
+        required: false
+        type: string
+        default: 'ubuntu-latest'
     secrets:
       ACR_LOGIN_SERVER:
         required: true
@@ -30,7 +34,7 @@ on:
 
 jobs:
   build-and-publish-container-image:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.RUNS_ON }}
     environment: ${{ inputs.ENVIRONMENT }}
     outputs:
       digest: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Add RUNS_ON input parameter to the reusable workflow to allow callers to specify the runner type. Defaults to 'ubuntu-latest' for backward compatibility.